### PR TITLE
Updated TestNetflix files for bc25793 / trh2349

### DIFF
--- a/bc25793-TestNetflix.c++
+++ b/bc25793-TestNetflix.c++
@@ -27,12 +27,12 @@ using namespace std;
  * by the side effects on the caches by other tests. */
 class NetflixFixture : public ::testing::Test {
 protected:
-    /** @brief Empty all the caches so no key value pairs remain. */
-    virtual void SetUp() {
-        movie_avg.clear();
-        user_dev.clear();
-        actual_ratings.clear();
-    }
+  /** @brief Empty all the caches so no key value pairs remain. */
+  virtual void SetUp() {
+    movie_avg.clear();
+    user_dev.clear();
+    actual_ratings.clear();
+  }
 };
 
 // ----
@@ -41,156 +41,150 @@ protected:
 
 /* Stub function for testing load_file */
 void load_stub(const char line[]) {
-    /* Make sure we don't get a null pointer */
-    ASSERT_TRUE(line);
-    return;
+  /* Make sure we don't get a null pointer */
+  ASSERT_TRUE(line);
+  return;
 }
 
 TEST_F(NetflixFixture, load_file_1) {
-    load_file("README.md", load_stub);
+  load_file("README.md", load_stub);
 
-    /* Ensure file read doesn't crash */
-    ASSERT_TRUE(true);
+  /* Ensure file read doesn't crash */
+  ASSERT_TRUE(true);
 }
 
 /* Tests for processing and storing movie average cache. */
 TEST_F(NetflixFixture, movie_avg_1) {
-    parse_movie_avg("1 2.34");
-    ASSERT_EQ(movie_avg[1], 2.34);
+  parse_movie_avg("1 2.34");
+  ASSERT_EQ(movie_avg[1], 2.34);
 }
 
 TEST_F(NetflixFixture, movie_avg_2) {
-    parse_movie_avg("0 5.67");
-    ASSERT_EQ(movie_avg[0], 5.67);
+  parse_movie_avg("0 5.67");
+  ASSERT_EQ(movie_avg[0], 5.67);
 }
 
 TEST_F(NetflixFixture, movie_avg_3) {
-    parse_movie_avg("100 -1234.1234");
-    ASSERT_EQ(movie_avg[100], -1234.1234);
+  parse_movie_avg("100 -1234.1234");
+  ASSERT_EQ(movie_avg[100], -1234.1234);
 }
 
 TEST_F(NetflixFixture, movie_avg_4) {
-    parse_movie_avg("-1234 0.9999");
-    ASSERT_EQ(movie_avg[-1234], 0.9999);
+  parse_movie_avg("-1234 0.9999");
+  ASSERT_EQ(movie_avg[-1234], 0.9999);
 }
 
 /* Tests for processing and storing user deviation cache. */
 TEST_F(NetflixFixture, user_dev_1) {
-    parse_user_dev("12 3.14");
-    ASSERT_EQ(user_dev[12], 3.14);
+  parse_user_dev("12 3.14");
+  ASSERT_EQ(user_dev[12], 3.14);
 }
 
 TEST_F(NetflixFixture, user_dev_2) {
-    parse_user_dev("95 -5.67");
-    ASSERT_EQ(user_dev[95], -5.67);
+  parse_user_dev("95 -5.67");
+  ASSERT_EQ(user_dev[95], -5.67);
 }
 
 TEST_F(NetflixFixture, user_dev_3) {
-    parse_user_dev("1995 0.99999");
-    ASSERT_EQ(user_dev[1995], 0.99999);
+  parse_user_dev("1995 0.99999");
+  ASSERT_EQ(user_dev[1995], 0.99999);
 }
 
 TEST_F(NetflixFixture, user_dev_4) {
-    parse_user_dev("0 -0.123");
-    ASSERT_EQ(user_dev[0], -0.123);
+  parse_user_dev("0 -0.123");
+  ASSERT_EQ(user_dev[0], -0.123);
 }
 
 /* Tests for processing and storing actual rating cache. */
 TEST_F(NetflixFixture, actual_ratings_1) {
-    parse_actual_ratings("55 1234 5");
-    ASSERT_EQ(actual_ratings[55][1234], 5);
+  parse_actual_ratings("55 1234 5");
+  ASSERT_EQ(actual_ratings[55][1234], 5);
 }
 
 TEST_F(NetflixFixture, actual_ratings_2) {
-    parse_actual_ratings("-99 4321 4");
-    ASSERT_EQ(actual_ratings[-99][4321], 4);
+  parse_actual_ratings("-99 4321 4");
+  ASSERT_EQ(actual_ratings[-99][4321], 4);
 }
 
 TEST_F(NetflixFixture, actual_ratings_3) {
-    parse_actual_ratings("6341 67 2");
-    ASSERT_EQ(actual_ratings[6341][67], 2);
+  parse_actual_ratings("6341 67 2");
+  ASSERT_EQ(actual_ratings[6341][67], 2);
 }
 
 /* Ensure predict_rating adds movie average and user deviation. */
 TEST_F(NetflixFixture, predict_rating_1) {
-    parse_movie_avg("1 2.1");
-    parse_user_dev("2 3.3");
-    ASSERT_EQ(predict_rating(1, 2), 5.4);
+  parse_movie_avg("1 2.1");
+  parse_user_dev("2 3.3");
+  ASSERT_EQ(predict_rating(1, 2), 5.4);
 }
 
 TEST_F(NetflixFixture, predict_rating_2) {
-    parse_movie_avg("2 1.5");
-    parse_user_dev("3 4.6");
-    ASSERT_EQ(predict_rating(2, 3), 6.1);
+  parse_movie_avg("2 1.5");
+  parse_user_dev("3 4.6");
+  ASSERT_EQ(predict_rating(2, 3), 6.1);
 }
 
 TEST_F(NetflixFixture, predict_rating_3) {
-    parse_movie_avg("1234 1234.5");
-    parse_user_dev("4321 8.987");
-    ASSERT_EQ(predict_rating(1234, 4321), 1243.487);
+  parse_movie_avg("1234 1234.5");
+  parse_user_dev("4321 8.987");
+  ASSERT_EQ(predict_rating(1234, 4321), 1243.487);
 }
 
 /* Ensure the RMSE value is properly calculated based on
    mean sum and count. */
-TEST_F(NetflixFixture, calc_rmse_1) {
-    ASSERT_EQ(calculate_rmse(0, 0), 0.0);
-}
+TEST_F(NetflixFixture, calc_rmse_1) { ASSERT_EQ(calculate_rmse(0, 0), 0.0); }
 
-TEST_F(NetflixFixture, calc_rmse_2) {
-    ASSERT_EQ(calculate_rmse(32, 2), 4.0);
-}
+TEST_F(NetflixFixture, calc_rmse_2) { ASSERT_EQ(calculate_rmse(32, 2), 4.0); }
 
-TEST_F(NetflixFixture, calc_rmse_3) {
-    ASSERT_EQ(calculate_rmse(100, 4), 5.0);
-}
+TEST_F(NetflixFixture, calc_rmse_3) { ASSERT_EQ(calculate_rmse(100, 4), 5.0); }
 
 /* Test the actual netflix_solve function based on sample cache
    data and sample input data. */
 TEST_F(NetflixFixture, netflix_solve_1) {
-    parse_actual_ratings("1 1234 3.0");
-    parse_movie_avg("1 2.0");
-    parse_user_dev("1234 0.5");
+  parse_actual_ratings("1 1234 3.0");
+  parse_movie_avg("1 2.0");
+  parse_user_dev("1234 0.5");
 
-    istringstream r("1:\n1234\n");
-    ostringstream w;
+  istringstream r("1:\n1234\n");
+  ostringstream w;
 
-    double rmse = netflix_solve(r, w, 0);
-    ASSERT_LT(rmse, 1.00);
-    ASSERT_GT(rmse, 0);    
+  double rmse = netflix_solve(r, w);
+  ASSERT_LT(rmse, 1.00);
+  ASSERT_GT(rmse, 0);
 }
 
 TEST_F(NetflixFixture, netflix_solve_2) {
-    parse_actual_ratings("9999 9999 5.0");
-    parse_movie_avg("9999 1.0");
-    parse_user_dev("9999 3.999");
+  parse_actual_ratings("9999 9999 5.0");
+  parse_movie_avg("9999 1.0");
+  parse_user_dev("9999 3.999");
 
-    istringstream r("9999:\n9999\n");
-    ostringstream w;
+  istringstream r("9999:\n9999\n");
+  ostringstream w;
 
-    double rmse = netflix_solve(r, w, 0);
-    ASSERT_LT(rmse, 1.00);
-    ASSERT_GT(rmse, 0);
+  double rmse = netflix_solve(r, w);
+  ASSERT_LT(rmse, 1.00);
+  ASSERT_GT(rmse, 0);
 }
 
 TEST_F(NetflixFixture, netflix_solve_3) {
-    parse_actual_ratings("10 4444 2.0");
-    parse_actual_ratings("11 4444 3.0");
-    parse_actual_ratings("12 4444 4.0");
-    parse_actual_ratings("10 5555 1.0");
-    parse_actual_ratings("11 5555 2.0");
-    parse_actual_ratings("12 5555 5.0");
+  parse_actual_ratings("10 4444 2.0");
+  parse_actual_ratings("11 4444 3.0");
+  parse_actual_ratings("12 4444 4.0");
+  parse_actual_ratings("10 5555 1.0");
+  parse_actual_ratings("11 5555 2.0");
+  parse_actual_ratings("12 5555 5.0");
 
-    parse_movie_avg("10 2.0");
-    parse_movie_avg("11 3.5");
-    parse_movie_avg("12 4.9");
+  parse_movie_avg("10 2.0");
+  parse_movie_avg("11 3.5");
+  parse_movie_avg("12 4.9");
 
-    parse_user_dev("4444 -.5");
-    parse_user_dev("5555 -.2");
+  parse_user_dev("4444 -.5");
+  parse_user_dev("5555 -.2");
 
-    istringstream r("10:\n4444\n5555\n11:\n4444\n5555\n12:\n4444\n5555\n");
-    ostringstream w;
+  istringstream r("10:\n4444\n5555\n11:\n4444\n5555\n12:\n4444\n5555\n");
+  ostringstream w;
 
-    double rmse = netflix_solve(r, w, 0);
-    ASSERT_LT(rmse, 1.00);
-    ASSERT_GT(rmse, 0);
+  double rmse = netflix_solve(r, w);
+  ASSERT_LT(rmse, 1.00);
+  ASSERT_GT(rmse, 0);
 }

--- a/bc25793-TestNetflix.out
+++ b/bc25793-TestNetflix.out
@@ -1,16 +1,16 @@
-==44421== Memcheck, a memory error detector
-==44421== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
-==44421== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
-==44421== Command: ./TestNetflix
-==44421== 
+==103834== Memcheck, a memory error detector
+==103834== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
+==103834== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
+==103834== Command: ./TestNetflix
+==103834== 
 Running main() from gtest_main.cc
 [==========] Running 21 tests from 1 test case.
 [----------] Global test environment set-up.
 [----------] 21 tests from NetflixFixture
 [ RUN      ] NetflixFixture.load_file_1
-[       OK ] NetflixFixture.load_file_1 (40 ms)
+[       OK ] NetflixFixture.load_file_1 (37 ms)
 [ RUN      ] NetflixFixture.movie_avg_1
-[       OK ] NetflixFixture.movie_avg_1 (45 ms)
+[       OK ] NetflixFixture.movie_avg_1 (42 ms)
 [ RUN      ] NetflixFixture.movie_avg_2
 [       OK ] NetflixFixture.movie_avg_2 (4 ms)
 [ RUN      ] NetflixFixture.movie_avg_3
@@ -18,23 +18,23 @@ Running main() from gtest_main.cc
 [ RUN      ] NetflixFixture.movie_avg_4
 [       OK ] NetflixFixture.movie_avg_4 (5 ms)
 [ RUN      ] NetflixFixture.user_dev_1
-[       OK ] NetflixFixture.user_dev_1 (3 ms)
+[       OK ] NetflixFixture.user_dev_1 (2 ms)
 [ RUN      ] NetflixFixture.user_dev_2
-[       OK ] NetflixFixture.user_dev_2 (3 ms)
+[       OK ] NetflixFixture.user_dev_2 (2 ms)
 [ RUN      ] NetflixFixture.user_dev_3
-[       OK ] NetflixFixture.user_dev_3 (3 ms)
+[       OK ] NetflixFixture.user_dev_3 (4 ms)
 [ RUN      ] NetflixFixture.user_dev_4
-[       OK ] NetflixFixture.user_dev_4 (3 ms)
+[       OK ] NetflixFixture.user_dev_4 (2 ms)
 [ RUN      ] NetflixFixture.actual_ratings_1
-[       OK ] NetflixFixture.actual_ratings_1 (41 ms)
+[       OK ] NetflixFixture.actual_ratings_1 (40 ms)
 [ RUN      ] NetflixFixture.actual_ratings_2
-[       OK ] NetflixFixture.actual_ratings_2 (9 ms)
+[       OK ] NetflixFixture.actual_ratings_2 (8 ms)
 [ RUN      ] NetflixFixture.actual_ratings_3
-[       OK ] NetflixFixture.actual_ratings_3 (3 ms)
+[       OK ] NetflixFixture.actual_ratings_3 (2 ms)
 [ RUN      ] NetflixFixture.predict_rating_1
-[       OK ] NetflixFixture.predict_rating_1 (3 ms)
+[       OK ] NetflixFixture.predict_rating_1 (4 ms)
 [ RUN      ] NetflixFixture.predict_rating_2
-[       OK ] NetflixFixture.predict_rating_2 (3 ms)
+[       OK ] NetflixFixture.predict_rating_2 (2 ms)
 [ RUN      ] NetflixFixture.predict_rating_3
 [       OK ] NetflixFixture.predict_rating_3 (3 ms)
 [ RUN      ] NetflixFixture.calc_rmse_1
@@ -44,28 +44,28 @@ Running main() from gtest_main.cc
 [ RUN      ] NetflixFixture.calc_rmse_3
 [       OK ] NetflixFixture.calc_rmse_3 (2 ms)
 [ RUN      ] NetflixFixture.netflix_solve_1
-[       OK ] NetflixFixture.netflix_solve_1 (41 ms)
+[       OK ] NetflixFixture.netflix_solve_1 (39 ms)
 [ RUN      ] NetflixFixture.netflix_solve_2
 [       OK ] NetflixFixture.netflix_solve_2 (8 ms)
 [ RUN      ] NetflixFixture.netflix_solve_3
-[       OK ] NetflixFixture.netflix_solve_3 (19 ms)
-[----------] 21 tests from NetflixFixture (254 ms total)
+[       OK ] NetflixFixture.netflix_solve_3 (18 ms)
+[----------] 21 tests from NetflixFixture (243 ms total)
 
 [----------] Global test environment tear-down
-[==========] 21 tests from 1 test case ran. (288 ms total)
+[==========] 21 tests from 1 test case ran. (275 ms total)
 [  PASSED  ] 21 tests.
-==44421== 
-==44421== HEAP SUMMARY:
-==44421==     in use at exit: 0 bytes in 0 blocks
-==44421==   total heap usage: 597 allocs, 597 frees, 90,401 bytes allocated
-==44421== 
-==44421== All heap blocks were freed -- no leaks are possible
-==44421== 
-==44421== For counts of detected and suppressed errors, rerun with: -v
-==44421== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
+==103834== 
+==103834== HEAP SUMMARY:
+==103834==     in use at exit: 0 bytes in 0 blocks
+==103834==   total heap usage: 597 allocs, 597 frees, 90,401 bytes allocated
+==103834== 
+==103834== All heap blocks were freed -- no leaks are possible
+==103834== 
+==103834== For counts of detected and suppressed errors, rerun with: -v
+==103834== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
 File 'Netflix.c++'
-Lines executed:95.08% of 61
-Branches executed:92.86% of 84
-Taken at least once:51.19% of 84
-Calls executed:81.43% of 70
+Lines executed:100.00% of 56
+Branches executed:100.00% of 76
+Taken at least once:55.26% of 76
+Calls executed:85.07% of 67
 Creating 'Netflix.c++.gcov'


### PR DESCRIPTION
Minor updates to bc25793-TestNetflix.c++ and bc25793-TestNetflix.out. A PR for our tests was already accepted; this PR contains newer versions of the files.